### PR TITLE
Use New JSX Transform on React Native

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -82,6 +82,21 @@ async function app() {
         { name: 'customize-cra', isDev: true },
         { name: '@types/react-native', isDev: true },
         { name: 'babel-plugin-import', isDev: true },
+        {
+            name: '@react-native-community/eslint-config',
+            version: '2.0.0',
+            isDev: true,
+        },
+        {
+            name: 'metro-react-native-babel-preset',
+            version: '0.64.0',
+            isDev: true,
+        },
+        {
+            name: 'eslint',
+            version: '7.14.0',
+            isDev: true,
+        },
     ], appName);
     // copy template files
     const templateDir = path_1.default.dirname(require.main.filename) + '/template';
@@ -92,11 +107,14 @@ async function app() {
     fs_extra_1.default.copySync(appNameWeb + '/src/serviceWorkerRegistration.ts', appName + '/src/serviceWorkerRegistration.ts', { overwrite: false });
     fs_extra_1.default.copySync(appNameWeb + '/public', appName + '/public');
     fs_extra_1.default.unlinkSync(appName + '/App.js');
-    const stream = fs_extra_1.default.createWriteStream(appName + '/.gitignore', { flags: 'a' });
-    stream.write('\n');
-    stream.write('.eslintcache');
-    stream.write('\n');
-    stream.end();
+    // Add .eslintcache to gitignore.
+    const gitignore = fs_extra_1.default.createWriteStream(appName + '/.gitignore', {
+        flags: 'a',
+    });
+    gitignore.write('\n');
+    gitignore.write('.eslintcache');
+    gitignore.write('\n');
+    gitignore.end();
     fs_extra_1.default.removeSync(appNameWeb);
     logSpaced("Yeah!! We're done!");
     logSpaced(`

--- a/dist/template/.eslintrc.js
+++ b/dist/template/.eslintrc.js
@@ -3,5 +3,7 @@ module.exports = {
   extends: '@react-native-community',
   rules: {
     'prettier/prettier': 0,
+    'react/jsx-uses-react': 0,
+    'react/react-in-jsx-scope': 0,
   },
 };

--- a/dist/template/babel.config.js
+++ b/dist/template/babel.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: [
+    [
+      '@babel/plugin-transform-react-jsx',
+      {
+        runtime: 'automatic',
+      },
+    ],
+  ],
+};

--- a/dist/template/src/AbstractionExample.tsx
+++ b/dist/template/src/AbstractionExample.tsx
@@ -1,10 +1,16 @@
-import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 
 export default function AbstractionExample() {
   return (
-    <View style={{ backgroundColor: '#EDEDED', padding: 10 }}>
+    <View style={styles.container}>
       <Text>I'm only on native devices :)</Text>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#EDEDED',
+    padding: 10,
+  },
+});

--- a/dist/template/src/AbstractionExample.web.tsx
+++ b/dist/template/src/AbstractionExample.web.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import './AbstractionExample.web.css';
 
 export default function AbstractionExample() {
   return (
-    <View style={{ backgroundColor: '#EDEDED', padding: 10 }}>
+    <View style={styles.container}>
       <Text>I'm only on web devices :)</Text>
       <div className="old-fashioned-div">
         This is just an old fashioned div with some crazy css
@@ -12,3 +11,10 @@ export default function AbstractionExample() {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#EDEDED',
+    padding: 10,
+  },
+});

--- a/dist/template/src/App.tsx
+++ b/dist/template/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import {
   View,
   Text,
@@ -12,7 +12,7 @@ import AbstractionExample from './AbstractionExample';
 
 export default function App() {
   const { width } = useWindowDimensions();
-  const [backgroundColor, setState] = React.useState<string>('#1275e6');
+  const [backgroundColor, setState] = useState<string>('#1275e6');
   return (
     <>
       <StatusBar

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "create-react-native-web-application is an easy way to get start with react-native-web",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "homepage": "https://github.com/web-ridge/react-ridge-state",
+  "homepage": "https://github.com/web-ridge/create-react-native-web-application",
   "license": "MIT",
   "readme": "README.md",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,21 @@ async function app() {
       { name: 'customize-cra', isDev: true },
       { name: '@types/react-native', isDev: true },
       { name: 'babel-plugin-import', isDev: true },
+      {
+        name: '@react-native-community/eslint-config',
+        version: '2.0.0',
+        isDev: true,
+      },
+      {
+        name: 'metro-react-native-babel-preset',
+        version: '0.64.0',
+        isDev: true,
+      },
+      {
+        name: 'eslint',
+        version: '7.14.0',
+        isDev: true,
+      },
     ],
     appName
   );
@@ -140,11 +155,14 @@ async function app() {
   fs.copySync(appNameWeb + '/public', appName + '/public');
   fs.unlinkSync(appName + '/App.js');
 
-  const stream = fs.createWriteStream(appName + '/.gitignore', { flags: 'a' });
-  stream.write('\n');
-  stream.write('.eslintcache');
-  stream.write('\n');
-  stream.end();
+  // Add .eslintcache to gitignore.
+  const gitignore = fs.createWriteStream(appName + '/.gitignore', {
+    flags: 'a',
+  });
+  gitignore.write('\n');
+  gitignore.write('.eslintcache');
+  gitignore.write('\n');
+  gitignore.end();
 
   fs.removeSync(appNameWeb);
 


### PR DESCRIPTION
Thanks for merging the previous PR. After testing out that PR a bit more I came across some DX issues and tried to fix those in this PR. This PR consists of the following: 

1. Removed React from the scope of all template files (To silence VSCode/TS Unused Variable warnings). 
2. Updated React Native Configs and Babel Config to use new JSX transform (No React is no defined error caused by Step 1). 
3. Added fix for #3 `__DEV__` is not defined using my proposed solution. 
4. Removed inline styles from template. 

This will ensure much better DX for using this package. We can revisit some of this after RN0.64 hits stable. Until then, I think this is all that's can be done. 

@RichardLindhout  What are your thoughts? 